### PR TITLE
fix: Include opportunity UUIDs in list_opportunities response (AGI-20)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 								text: `Found ${result.total} opportunities:\n\n${result.opportunities
 									.map(
 										(opp) =>
-											`• ${opp.opportunity_name} (${opp.agency}) - Status: ${opp.status || "Not Started"} - Priority: ${opp.priority || "Not Set"}`
+											`• [${opp.id}] ${opp.opportunity_name} (${opp.agency}) - Status: ${opp.status || "Not Started"} - Priority: ${opp.priority || "Not Set"}`
 									)
 									.join("\n")}\n\nShowing ${result.total} results (offset: ${result.offset}, limit: ${result.limit})`,
 							},


### PR DESCRIPTION
- Add UUID to each opportunity in the list display format
- Format: [uuid] opportunity_name (agency) - Status - Priority
- Enables users to copy UUIDs for use with get/update/delete operations
- Fixes broken workflow where opportunities could be listed but not interacted with

Closes AGI-20

🤖 Generated with [Claude Code](https://claude.ai/code)